### PR TITLE
Pin eslint@2.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.4.3",
     "chai": "^3.4.1",
-    "eslint": "^2.0.0",
+    "eslint": "~2.2.0",
     "eslint-config-kellyirc": "^3.1.0",
     "mocha": "^2.3.4",
     "onchange": "^2.0.0"


### PR DESCRIPTION
eslint v2.3.0 breaks our builds because of babel-eslint using a dependency that v2.3.0 removed. Pinning to 2.2.x until this is fixed in babel-eslint.